### PR TITLE
don't upload timestamp column direct to clickhouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To initialize the table schema to ingest into, run `initialize.py` (after editin
 **WARNING: THIS WILL DELETE THE TABLE IF IT ALREADY EXISTED**
 
 To bulk-ingest json files produced by the json dumper in `load_main.py` from the `treasury_accounting` repo (meant for Druid ingestion), run
-` ls ./ledger_2021-02-01* | while read p; do cat $p | clickhouse-client --database=ledger --query="INSERT INTO ledger FORMAT JSONEachRow"; done`
+` ls ./ledger_2021-02-01* | while read p; do cat $p | clickhouse-client --database=ledger --input_format_skip_unknown_fields=1 --query="INSERT INTO ledger FORMAT JSONEachRow"; done`
 from the command line in the directory where those files live (assuming the server runs on the same machine).
 ## Starting SeekTable
 On your local machine, change into the `seektable` directory and run `docker-compose up`. 

--- a/src/clickhouse_utils/initialize.py
+++ b/src/clickhouse_utils/initialize.py
@@ -49,9 +49,9 @@ if __name__ == "__main__":
 
     root_dir = os.path.realpath("../../..")
 
-    # this script needs at least one json file to exist, to infer the schema from
+    #this script needs at least one json file to exist, to infer the schema from
     data_loc = os.path.join(
-        root_dir, "treasury_accounting/druid/raw_data/ledger_2021-02-01_0.json"
+        root_dir, "treasury_accounting/druid/raw_data/ledger_2021-03-01_0.json"
     )
     data = jsons_files_to_iterable(data_loc)
 
@@ -70,14 +70,15 @@ if __name__ == "__main__":
 
     client = Client(host=host, port=port)
     dtypes = next(iter(data)).dtypes
+    dtypes.drop("TIMESTAMP", inplace=True)  # clickhouse cannot handle millisecond timestamps
 
     initialize_schema(
         client,
         database_name="ledger",
-        table_name="ledger",
+        table_name="ledger_base",
         dtypes=dtypes,
         uid_name="ID",
-        time_col="TIMESTAMP",
+        time_col="EVENT_TIMESTAMP",
         high_granularity=high_cardinality,
         flush_table=True,
     )


### PR DESCRIPTION
Clickhouse parses millisecond granularity timestamps incorrectly; with this change we skip the TIMESTAMP column when ingesting to clickhouse. It can be recreated in clickhouse using EVENT_TIMESTAMP. We do this as a view.

## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

### Changes

<!-- What changes have you made? Anything else we should keep in mind? -->

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
