### PR TITLE
enable other authentification methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tw-experimentation"
-version = "0.1.2.3"
+version = "0.1.2.4"
 description = "Wise AB platform"
 authors = ["Wise"]
 readme = "README.md"

--- a/tw_experimentation/streamlit/pages_wrap/page1_Data_Loading.py
+++ b/tw_experimentation/streamlit/pages_wrap/page1_Data_Loading.py
@@ -111,8 +111,10 @@ def page_1_data_loading(snowflake_connector=SnowflakeIndividualCredentials()):
                 st.session_state["snowflake_" + config_variable],
                 disabled=not (enter_credentials or restart_snowflake),
             )
-
-        if st.button("Fetch data from snowflake"):
+        if not st.session_state["fetch_from_snowflake_button"]:
+            if st.button("Fetch data from snowflake"):
+                st.session_state["fetch_from_snowflake_button"] = True
+        if st.session_state["fetch_from_snowflake_button"]:
             account_configs = {
                 config_variable: st.session_state["snowflake_" + config_variable]
                 for config_variable in st.session_state[
@@ -136,6 +138,7 @@ def page_1_data_loading(snowflake_connector=SnowflakeIndividualCredentials()):
                     source_table=st.session_state["table"],
                 )
             st.session_state.has_snowflake_connection = True
+            st.session_state["fetch_from_snowflake_button"] = False
 
     if st.session_state["df_temp"] is not None:
         st.divider()

--- a/tw_experimentation/streamlit/streamlit_utils.py
+++ b/tw_experimentation/streamlit/streamlit_utils.py
@@ -86,7 +86,7 @@ class SnowflakeConnection(ABC):
                 select * from {source_database}.{source_schema}.{source_table}
                 """
         df = pd.read_sql(sql_query, self.connection)
-
+        st.session_state["fetch_from_snowflake_button"] = False
         return df
 
     def close_connection(self):
@@ -178,6 +178,7 @@ def initalise_session_states(additional_params: Optional[Dict] = dict()):
         "ed": None,
         "data_loader": PullAndMatchData(),
         "snowflake_connection": None,
+        "fetch_from_snowflake_button": False,
         "df_temp": None,
         "is_defined_data_model": False,
         "evaluate_CUPED": False,


### PR DESCRIPTION
## Context

Making minor changes to enable other authentication methods via snowflake downstream (e.g. via Okta) with arbitrary warehouses



## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
